### PR TITLE
fix(rustup): rustc 1.0.0-nightly (be9bd7c93 2015-04-05)

### DIFF
--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -6,7 +6,7 @@ pub trait Invoke<A> {
 
 //////////////////////////////////////////////////////////////////////////////
 
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct Identity;
 
 impl<A> Invoke<A> for Identity {


### PR DESCRIPTION
`Copy` doesn't imply the `Clone` trait anymore,
which now has to be specified explicitly.
... it seems
