### PR TITLE
Add with-fields to StructDefBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,12 @@ impl AstBuilder {
         variant::VariantBuilder::new(id).span(self.span)
     }
 
+    pub fn field<T>(&self, id: T) -> struct_def::StructFieldBuilder
+        where T: ident::ToIdent,
+    {
+        struct_def::StructFieldBuilder::named(id).span(self.span)
+    }
+
     pub fn item(&self) -> item::ItemBuilder {
         item::ItemBuilder::new().span(self.span)
     }

--- a/src/struct_def.rs
+++ b/src/struct_def.rs
@@ -37,6 +37,13 @@ impl<F> StructDefBuilder<F>
         self
     }
 
+    pub fn with_fields<I>(mut self, iter: I) -> Self
+        where I: IntoIterator<Item=ast::StructField>,
+    {
+        self.fields.extend(iter);
+        self
+    }
+
     pub fn with_field(mut self, field: ast::StructField) -> Self {
         self.fields.push(field);
         self

--- a/tests/test_struct_def.rs
+++ b/tests/test_struct_def.rs
@@ -124,3 +124,25 @@ fn test_attrs() {
         })
     );
 }
+
+
+#[test]
+fn test_with_fields() {
+    let builder = AstBuilder::new();
+    let struct_def = builder.struct_def()
+        .field("x").ty().isize()
+        .field("y").ty().isize()
+        .build();
+
+    let struct_def2 = builder.struct_def()
+        .with_fields(
+            vec!["x","y"].iter()
+                .map(|f| builder.field(f).ty().isize())
+            )
+        .build();
+
+    assert_eq!(
+        struct_def,
+        struct_def2
+    );
+}


### PR DESCRIPTION
Allow construction of fields based on an iterator.

Also adds the `field` method to AstBuilder.
