### PR TITLE
Add ty_ to ItemBuilder for type aliases

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -143,6 +143,20 @@ impl<F> ItemBuilder<F>
         }
 
     }
+
+    pub fn ty_<T>(self, id: T) -> ItemTyBuilder<F>
+        where T: ToIdent,
+    {
+        let id = id.to_ident();
+        let generics = GenericsBuilder::new().build();
+
+        ItemTyBuilder {
+            builder: self,
+            id: id,
+            generics: generics,
+        }
+
+    }
 }
 
 impl<F> Invoke<ast::Attribute> for ItemBuilder<F>
@@ -567,5 +581,51 @@ impl<F> Invoke<P<ast::Variant>> for ItemEnumBuilder<F>
 
     fn invoke(self, variant: P<ast::Variant>) -> Self {
         self.with_variant(variant)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+pub struct ItemTyBuilder<F> {
+    builder: ItemBuilder<F>,
+    id: ast::Ident,
+    generics: ast::Generics,
+}
+
+impl<F> ItemTyBuilder<F>
+    where F: Invoke<P<ast::Item>>,
+{
+    pub fn generics(self) -> GenericsBuilder<Self> {
+        GenericsBuilder::new_with_callback(self)
+    }
+
+    pub fn ty(self) -> TyBuilder<Self> {
+        TyBuilder::new_with_callback(self)
+    }
+
+    pub fn build_ty(self, ty: P<ast::Ty>) -> F::Result {
+        let ty_ = ast::ItemTy(ty, self.generics);
+        self.builder.build_item_(self.id, ty_)
+    }
+}
+
+impl<F> Invoke<ast::Generics> for ItemTyBuilder<F>
+    where F: Invoke<P<ast::Item>>,
+{
+    type Result = Self;
+
+    fn invoke(mut self, generics: ast::Generics) -> Self {
+        self.generics = generics;
+        self
+    }
+}
+
+impl<F> Invoke<P<ast::Ty>> for ItemTyBuilder<F>
+    where F: Invoke<P<ast::Item>>,
+{
+    type Result = F::Result;
+
+    fn invoke(self, ty: P<ast::Ty>) -> F::Result {
+        self.build_ty(ty)
     }
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -404,3 +404,25 @@ fn test_attr() {
         })
     );
 }
+
+#[test]
+fn test_ty() {
+    let builder = AstBuilder::new();
+    let enum_= builder.item().ty_("MyT")
+        .ty().isize();
+
+    assert_eq!(
+        enum_,
+        P(ast::Item {
+            ident: builder.id("MyT"),
+            id: ast::DUMMY_NODE_ID,
+            attrs: vec![],
+            node: ast::ItemTy(
+                builder.ty().isize(),
+                builder.generics().build(),
+            ),
+            vis: ast::Inherited,
+            span: DUMMY_SP,
+        })
+    );
+}


### PR DESCRIPTION
Allow building of type bindings.

I'm not sure the naming is the clearest, but I tried to be consistent
with the existing methods and ast::Item_.
