### PR TITLE
Add mac to ItemBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod invoke;
 pub mod item;
 pub mod lifetime;
 pub mod lit;
+pub mod mac;
 pub mod method;
 pub mod name;
 pub mod pat;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,0 +1,116 @@
+use syntax::ast;
+use syntax::codemap::{self, DUMMY_SP, Span, respan};
+use syntax::ext::base::ExtCtxt;
+use syntax::ext::expand;
+use syntax::ext::quote::rt::ToTokens;
+use syntax::parse::{self, ParseSess};
+use syntax::ptr::P;
+
+use expr::ExprBuilder;
+use invoke::{Invoke, Identity};
+
+/// A Builder for macro invocations.
+///
+/// Note that there are no commas added between args, as otherwise
+/// that macro invocations that could be expressed would be limited.
+/// You will need to add all required symbols with `with_arg` or
+/// `with_argss`.
+pub struct MacBuilder<F=Identity> {
+    callback: F,
+    span: Span,
+    tokens: Vec<ast::TokenTree>,
+    path: Option<ast::Path>,
+}
+
+impl MacBuilder {
+    pub fn new() -> Self {
+        MacBuilder::new_with_callback(Identity)
+    }
+}
+
+impl<F> MacBuilder<F>
+    where F: Invoke<ast::Mac>
+{
+    pub fn new_with_callback(callback: F) -> Self {
+        MacBuilder {
+            callback: callback,
+            span: DUMMY_SP,
+            tokens: vec![],
+            path: None,
+        }
+    }
+
+    pub fn span(mut self, span: Span) -> Self {
+        self.span = span;
+        self
+    }
+
+    pub fn path(mut self, path: ast::Path) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    pub fn build(self) -> F::Result {
+        let mac = ast::Mac_::MacInvocTT(
+            self.path.expect("No path set for macro"), self.tokens, 0);
+        self.callback.invoke(respan(self.span, mac))
+    }
+
+    pub fn with_args<I, T>(self, iter: I) -> Self
+        where I: IntoIterator<Item=T>, T: ToTokens
+    {
+        iter.into_iter().fold(self, |self_, expr| self_.with_arg(expr))
+    }
+
+    pub fn with_arg<T>(mut self, expr: T) -> Self
+        where T: ToTokens
+    {
+        use syntax::ext::quote::rt::ToTokens;
+        let parse_sess = parse::new_parse_sess();
+        let cx = make_ext_ctxt(&parse_sess);
+        let tokens = expr.to_tokens(&cx);
+        assert!(tokens.len() == 1);
+        self.tokens.push(tokens[0].clone());
+        self
+    }
+
+    pub fn expr(self) -> ExprBuilder<Self> {
+        ExprBuilder::new_with_callback(self)
+    }
+
+}
+
+impl<F> Invoke<P<ast::Expr>> for MacBuilder<F>
+    where F: Invoke<ast::Mac>,
+{
+    type Result = Self;
+
+    fn invoke(self, expr: P<ast::Expr>) -> Self {
+        self.with_arg(expr)
+    }
+}
+
+fn make_ext_ctxt(sess: &ParseSess) -> ExtCtxt {
+    let info = codemap::ExpnInfo {
+        call_site: codemap::DUMMY_SP,
+        callee: codemap::NameAndSpan {
+            name: "test".to_string(),
+            format: codemap::MacroAttribute,
+            allow_internal_unstable: false,
+            span: None
+        }
+    };
+
+    let cfg = vec![];
+    let ecfg = expand::ExpansionConfig {
+        crate_name: String::new(),
+        features: None,
+        recursion_limit: 64,
+        trace_mac: false,
+    };
+
+    let mut cx = ExtCtxt::new(&sess, cfg, ecfg);
+    cx.bt_push(info);
+
+    cx
+}

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -7,6 +7,7 @@ use syntax::abi::Abi;
 use syntax::ast;
 use syntax::codemap::{DUMMY_SP, Spanned, respan};
 use syntax::parse::token;
+use syntax::print::pprust;
 use syntax::ptr::P;
 
 use aster::AstBuilder;
@@ -403,4 +404,36 @@ fn test_attr() {
             span: DUMMY_SP,
         })
     );
+}
+
+#[test]
+fn test_mac() {
+    let builder = AstBuilder::new();
+    let mac = builder.item().mac()
+        .path().id("my_macro").build()
+        .expr().str("abc")
+        .expr().id(",")
+        .expr().build_add(builder.expr().u32(0), builder.expr().u32(1))
+        .build();
+
+    assert_eq!(
+        &pprust::item_to_string(&mac)[..],
+        "my_macro! (\"abc\" , 0u32 + 1u32);"
+        );
+
+    let mac = builder.item().mac()
+        .path().id("my_macro").build()
+        .with_args(
+            vec![
+                builder.expr().str("abc"),
+                builder.expr().id(","),
+                builder.expr().build_add(builder.expr().u32(0), builder.expr().u32(1))
+                ]
+            )
+        .build();
+
+    assert_eq!(
+        &pprust::item_to_string(&mac)[..],
+        "my_macro! (\"abc\" , 0u32 + 1u32);"
+        );
 }


### PR DESCRIPTION
Allow construction of macro invocation items.

Note: This uses ToTokens to convert ast:Expr back into tokens.
