### PR TITLE
Add extern_crate to ItemBuilder

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -143,6 +143,17 @@ impl<F> ItemBuilder<F>
         }
 
     }
+
+    pub fn extern_crate<T>(self, id: T) -> ItemExternCrateBuilder<F>
+        where T: ToIdent,
+    {
+        let id = id.to_ident();
+
+        ItemExternCrateBuilder {
+            builder: self,
+            id: id,
+        }
+    }
 }
 
 impl<F> Invoke<ast::Attribute> for ItemBuilder<F>
@@ -567,5 +578,27 @@ impl<F> Invoke<P<ast::Variant>> for ItemEnumBuilder<F>
 
     fn invoke(self, variant: P<ast::Variant>) -> Self {
         self.with_variant(variant)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+/// A builder for extern crate items
+pub struct ItemExternCrateBuilder<F> {
+    builder: ItemBuilder<F>,
+    id: ast::Ident,
+}
+
+impl<F> ItemExternCrateBuilder<F>
+    where F: Invoke<P<ast::Item>>,
+{
+    pub fn with_name(self, name: ast::Name) -> F::Result {
+        let extern_ = ast::ItemExternCrate(Some(name));
+        self.builder.build_item_(self.id, extern_)
+    }
+
+    pub fn build(self) -> F::Result {
+        let extern_ = ast::ItemExternCrate(None);
+        self.builder.build_item_(self.id, extern_)
     }
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -404,3 +404,41 @@ fn test_attr() {
         })
     );
 }
+
+#[test]
+fn test_extern_crate() {
+    use aster::name::ToName;
+
+    let builder = AstBuilder::new();
+    let item = builder.item()
+        .extern_crate("aster")
+        .build();
+
+    assert_eq!(
+        item,
+        P(ast::Item {
+            ident: builder.id("aster"),
+            attrs: vec![],
+            id: ast::DUMMY_NODE_ID,
+            node: ast::ItemExternCrate(None),
+            vis: ast::Inherited,
+            span: DUMMY_SP,
+        })
+    );
+
+    let item = builder.item()
+        .extern_crate("aster")
+        .with_name("aster1".to_name());
+
+    assert_eq!(
+        item,
+        P(ast::Item {
+            ident: builder.id("aster"),
+            attrs: vec![],
+            id: ast::DUMMY_NODE_ID,
+            node: ast::ItemExternCrate(Some("aster1".to_name())),
+            vis: ast::Inherited,
+            span: DUMMY_SP,
+        })
+    );
+}


### PR DESCRIPTION
Adds the ability to create `extern use` items.
