### PR TITLE
Fix build on latest nightly

### DIFF
--- a/src/mac.rs
+++ b/src/mac.rs
@@ -3,7 +3,7 @@ use syntax::codemap::{self, DUMMY_SP, Span, respan};
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::expand;
 use syntax::ext::quote::rt::ToTokens;
-use syntax::parse::{self, ParseSess};
+use syntax::parse::ParseSess;
 use syntax::ptr::P;
 
 use expr::ExprBuilder;
@@ -65,7 +65,7 @@ impl<F> MacBuilder<F>
     pub fn with_arg<T>(mut self, expr: T) -> Self
         where T: ToTokens
     {
-        let parse_sess = parse::new_parse_sess();
+        let parse_sess = ParseSess::new();
         let cx = make_ext_ctxt(&parse_sess);
         let tokens = expr.to_tokens(&cx);
         assert!(tokens.len() == 1);


### PR DESCRIPTION
Due to [changes in libsyntax](https://github.com/rust-lang/rust/commit/c23a9d42ea082830593a73d25821842baf9ccf33), building `aster` is broken on:
rustc 1.2.0-nightly (c23a9d42e 2015-05-17) (built 2015-05-17)

This fixes it for me.
