### PR TITLE
fix(rustup): 1.2.0 (7cb9914fc 2015-05-25)

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -207,6 +207,7 @@ impl<F> Invoke<P<ast::FnDecl>> for ItemFnDeclBuilder<F>
             id: self.id,
             fn_decl: fn_decl,
             unsafety: ast::Unsafety::Normal,
+            constness: ast::Constness::NotConst,
             abi: Abi::Rust,
             generics: generics,
         }
@@ -220,6 +221,7 @@ pub struct ItemFnBuilder<F> {
     id: ast::Ident,
     fn_decl: P<ast::FnDecl>,
     unsafety: ast::Unsafety,
+    constness: ast::Constness,
     abi: Abi,
     generics: ast::Generics,
 }
@@ -245,6 +247,7 @@ impl<F> ItemFnBuilder<F>
         self.builder.build_item_(self.id, ast::Item_::ItemFn(
             self.fn_decl,
             self.unsafety,
+            self.constness,
             self.abi,
             self.generics,
             block,

--- a/src/method.rs
+++ b/src/method.rs
@@ -19,6 +19,7 @@ pub struct MethodBuilder<F=Identity> {
     abi: Abi,
     generics: ast::Generics,
     unsafety: ast::Unsafety,
+    constness: ast::Constness,
     id: ast::Ident,
     vis: ast::Visibility,
 }
@@ -42,6 +43,7 @@ impl<F> MethodBuilder<F>
             abi: Abi::Rust,
             generics: GenericsBuilder::new().build(),
             unsafety: ast::Unsafety::Normal,
+            constness: ast::Constness::NotConst,
             id: id.to_ident(),
             vis: ast::Visibility::Inherited,
         }
@@ -161,6 +163,7 @@ impl<F> Invoke<P<ast::Block>> for MethodSelfFnDeclBuilder<F>
         let method_sig = ast::MethodSig {
             unsafety: self.builder.unsafety,
             abi: self.builder.abi,
+            constness: self.builder.constness,
             decl: self.fn_decl,
             generics: self.builder.generics,
             explicit_self: self.explicit_self,

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -31,6 +31,7 @@ fn test_fn() {
             node: ast::ItemFn(
                 builder.fn_decl().return_().isize(),
                 ast::Unsafety::Normal,
+                ast::Constness::NotConst,
                 Abi::Rust,
                 builder.generics().build(),
                 block
@@ -68,6 +69,7 @@ fn test_generic_fn() {
             node: ast::ItemFn(
                 builder.fn_decl().return_().isize(),
                 ast::Unsafety::Normal,
+                ast::Constness::NotConst,
                 Abi::Rust,
                 builder.generics()
                     .lifetime("'a").build()


### PR DESCRIPTION
Adjusted method signatures to deal with the recently added `Constness`
flag.

For now it just defaults to `NotConst` which seems a reasonable default.
However, I must admit I have no idea what I was doing, except to make
builds work with the latest nightly (also with `cargo test`).

Unfortunately, this makes the code incompatible with stable, which could
probably be considered a problem.

This PR might just be a hint and for others to see in case they have
the same problems ... and I wouldn't consider it an actual fix.

As a last note: even though this compiles on a recent nightly, in case
you want to use `serde_macros`, these will not work due to other issues
that are beyond my fixing capabilities.
