### PR TITLE
ItemImplBuilder, ItemImplItemBuilder, ConstBuilder, ItemConstBuilder, MethodBuilder refactor, float literal support

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,0 +1,87 @@
+use syntax::ast;
+use syntax::codemap::{DUMMY_SP, Span};
+use syntax::ptr::P;
+
+use expr::ExprBuilder;
+use invoke::{Invoke, Identity};
+use ty::TyBuilder;
+
+//////////////////////////////////////////////////////////////////////////////
+
+pub struct Const {
+    pub ty: P<ast::Ty>,
+    pub expr: Option<P<ast::Expr>>,
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+pub struct ConstBuilder<F=Identity> {
+    callback: F,
+    span: Span,
+    expr: Option<P<ast::Expr>>,
+}
+
+impl ConstBuilder {
+    pub fn new() -> Self {
+        ConstBuilder::new_with_callback(Identity)
+    }
+}
+
+impl<F> ConstBuilder<F>
+    where F: Invoke<Const>,
+{
+    pub fn new_with_callback(callback: F) -> Self
+        where F: Invoke<Const>,
+    {
+        ConstBuilder {
+            callback: callback,
+            span: DUMMY_SP,
+            expr: None,
+        }
+    }
+
+    pub fn span(mut self, span: Span) -> Self {
+        self.span = span;
+        self
+    }
+
+    pub fn with_expr(mut self, expr: P<ast::Expr>) -> Self {
+        self.expr = Some(expr);
+        self
+    }
+
+    pub fn expr(self) -> ExprBuilder<Self> {
+        ExprBuilder::new_with_callback(self)
+    }
+
+    pub fn ty(self) -> TyBuilder<Self> {
+        TyBuilder::new_with_callback(self)
+    }
+
+    pub fn build(self, ty: P<ast::Ty>) -> F::Result {
+        self.callback.invoke(Const {
+            ty: ty,
+            expr: self.expr,
+        })
+    }
+}
+
+impl<F> Invoke<P<ast::Expr>> for ConstBuilder<F>
+    where F: Invoke<Const>,
+{
+    type Result = Self;
+
+    fn invoke(self, expr: P<ast::Expr>) -> Self {
+        self.with_expr(expr)
+    }
+}
+
+impl<F> Invoke<P<ast::Ty>> for ConstBuilder<F>
+    where F: Invoke<Const>,
+{
+    type Result = F::Result;
+
+    fn invoke(self, ty: P<ast::Ty>) -> F::Result {
+        self.build(ty)
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -132,6 +132,18 @@ impl<F> ExprBuilder<F>
         self.lit().u64(value)
     }
 
+    pub fn f32<S>(self, value: S) -> F::Result
+        where S: ToInternedString,
+    {
+        self.lit().f32(value)
+    }
+
+    pub fn f64<S>(self, value: S) -> F::Result
+        where S: ToInternedString,
+    {
+        self.lit().f64(value)
+    }
+
     pub fn str<S>(self, value: S) -> F::Result
         where S: ToInternedString,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use syntax::parse::token;
 
 pub mod attr;
 pub mod block;
+pub mod constant;
 pub mod expr;
 pub mod fn_decl;
 pub mod generics;
@@ -136,10 +137,8 @@ impl AstBuilder {
         fn_decl::FnDeclBuilder::new().span(self.span)
     }
 
-    pub fn method<I>(&self, id: I) -> method::MethodBuilder
-        where I: ident::ToIdent,
-    {
-        method::MethodBuilder::new(id).span(self.span)
+    pub fn method(&self) -> method::MethodBuilder {
+        method::MethodBuilder::new().span(self.span)
     }
 
     pub fn arg<I>(&self, id: I) -> fn_decl::ArgBuilder
@@ -166,5 +165,9 @@ impl AstBuilder {
 
     pub fn item(&self) -> item::ItemBuilder {
         item::ItemBuilder::new().span(self.span)
+    }
+
+    pub fn const_(&self) -> constant::ConstBuilder {
+        constant::ConstBuilder::new().span(self.span)
     }
 }

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -99,6 +99,24 @@ impl<F> LitBuilder<F>
         self.build_uint(value, ast::UintTy::TyU64)
     }
 
+    fn build_float<S>(self, value: S, ty: ast::FloatTy) -> F::Result
+        where S: ToInternedString,
+    {
+        self.build_lit(ast::LitFloat(value.to_interned_string(), ty))
+    }
+
+    pub fn f32<S>(self, value: S) -> F::Result
+        where S: ToInternedString,
+    {
+        self.build_float(value, ast::FloatTy::TyF32)
+    }
+
+    pub fn f64<S>(self, value: S) -> F::Result
+        where S: ToInternedString,
+    {
+        self.build_float(value, ast::FloatTy::TyF64)
+    }
+
     pub fn str<S>(self, value: S) -> F::Result
         where S: ToInternedString,
     {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -113,6 +113,14 @@ impl<F> TyBuilder<F>
         self.id("u64")
     }
 
+    pub fn f32(self) -> F::Result {
+        self.id("f32")
+    }
+
+    pub fn f64(self) -> F::Result {
+        self.id("f64")
+    }
+
     pub fn unit(self) -> F::Result {
         self.tuple().build()
     }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -514,3 +514,115 @@ fn test_type() {
         })
     );
 }
+
+#[test]
+fn test_impl() {
+    let builder = AstBuilder::new();
+    let impl_ = builder.item().impl_()
+        .trait_().id("ser").id("Serialize").build()
+
+        // Type
+        .item("MyFloat").type_().f64()
+
+        // Const
+        .item("PI").const_()
+            .expr().f64("3.14159265358979323846264338327950288")
+            .ty().f64()
+
+        // Method
+        .item("serialize").method()
+            .fn_decl()
+                .arg("serializer").ty().ref_().mut_().ty().path().id("ser").id("Serialize").build()
+                .default_return()
+            .block().build() // empty method block
+            .build()
+
+        .ty().id("MySerializer");
+
+    assert_eq!(
+        impl_,
+        P(ast::Item {
+            ident: builder.id(""),
+            id: ast::DUMMY_NODE_ID,
+            attrs: vec![],
+            node: ast::ItemImpl(
+                ast::Unsafety::Normal,
+                ast::ImplPolarity::Positive,
+                builder.generics().build(),
+                Some(ast::TraitRef {
+                    path: builder.path().id("ser").id("Serialize").build(),
+                    ref_id: 0
+                }),
+                builder.ty().id("MySerializer"),
+                vec![
+                    P(ast::ImplItem {
+                        id: ast::DUMMY_NODE_ID,
+                        ident: builder.id("MyFloat"),
+                        vis: ast::Visibility::Inherited,
+                        attrs: vec![],
+                        node: ast::TypeImplItem(builder.ty().f64()),
+                        span: DUMMY_SP,
+                    }),
+
+                    P(ast::ImplItem {
+                        id: ast::DUMMY_NODE_ID,
+                        ident: builder.id("PI"),
+                        vis: ast::Visibility::Inherited,
+                        attrs: vec![],
+                        node: ast::ConstImplItem(
+                            builder.ty().f64(),
+                            builder.expr().f64("3.14159265358979323846264338327950288"),
+                        ),
+                        span: DUMMY_SP,
+                    }),
+
+                    P(ast::ImplItem {
+                        id: ast::DUMMY_NODE_ID,
+                        ident: builder.id("serialize"),
+                        vis: ast::Visibility::Inherited,
+                        attrs: vec![],
+                        node: ast::MethodImplItem(
+                            ast::MethodSig {
+                                unsafety: ast::Unsafety::Normal,
+                                constness: ast::Constness::NotConst,
+                                abi: Abi::Rust,
+                                decl: builder.fn_decl()
+                                    .arg("serializer").ty().ref_().mut_().ty().path().id("ser").id("Serialize").build()
+                                    .default_return(),
+                                generics: builder.generics().build(),
+                                explicit_self: respan(DUMMY_SP, ast::ExplicitSelf_::SelfStatic),
+                            },
+                            builder.block().build()
+                        ),
+                        span: DUMMY_SP,
+                    })
+                ]
+            ),
+            vis: ast::Visibility::Inherited,
+            span: DUMMY_SP,
+        })
+    );
+}
+
+#[test]
+fn test_const() {
+    let builder = AstBuilder::new();
+    let const_ = builder.item().const_("PI")
+        .expr().f64("3.14159265358979323846264338327950288")
+        .ty().f64();
+
+    assert_eq!(
+        const_,
+        P(ast::Item {
+            ident: builder.id("PI"),
+            id: ast::DUMMY_NODE_ID,
+            attrs: vec![],
+            node: ast::ItemConst(
+                builder.ty().f64(),
+                builder.expr().f64("3.14159265358979323846264338327950288")
+            ),
+            vis: ast::Visibility::Inherited,
+            span: DUMMY_SP,
+        })
+    );
+}


### PR DESCRIPTION
Refactor MethodBuilder to be simpler, have a default starting point, and more flexible in terms of composing its parts. It can be used generically for composing either a MethodImplItem or a MethodTraitItem.
Add ConstBuilder, a generic const builder that can be used generically for composing either a ConstImplItem, ConstTraitItem, or an ItemConst.
Add float support to LitBuilder and ExprBuilder.
Add ItemImplBuilder and ItemImplItemBuilder to compose ItemImpl and ImplItem nodes.
