### PR TITLE
Update for compatibility with rust PR28033

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A libsyntax ast builder"

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -5,6 +5,7 @@ use syntax::ext::expand;
 use syntax::ext::quote::rt::ToTokens;
 use syntax::feature_gate::GatedCfg;
 use syntax::parse::ParseSess;
+use syntax::parse::token::intern;
 use syntax::ptr::P;
 
 use expr::ExprBuilder;
@@ -96,8 +97,7 @@ fn make_ext_ctxt<'a>(sess: &'a ParseSess,
     let info = codemap::ExpnInfo {
         call_site: codemap::DUMMY_SP,
         callee: codemap::NameAndSpan {
-            name: "test".to_string(),
-            format: codemap::MacroAttribute,
+            format: codemap::MacroBang(intern("test")),
             allow_internal_unstable: false,
             span: None
         }


### PR DESCRIPTION
For compatibility with https://github.com/rust-lang/rust/pull/28033, in codemap::NameAndSpan remove the name field and change the format field from MacroAttribute to MacroBang(name).

Bump version number.
