### PR TITLE
chore(rustup): update to rustc 1.6.0-nightly (11ba81e10 2015-10-31)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A libsyntax ast builder"

--- a/src/item.rs
+++ b/src/item.rs
@@ -470,7 +470,7 @@ impl<F> Invoke<P<ast::VariantData>> for ItemStructBuilder<F>
     type Result = F::Result;
 
     fn invoke(self, data: P<ast::VariantData>) -> F::Result {
-        let struct_ = ast::ItemStruct(data, self.generics);
+        let struct_ = ast::ItemStruct(data.and_then(|d| d), self.generics);
         self.builder.build_item_(self.id, struct_)
     }
 }
@@ -511,7 +511,7 @@ impl<F> ItemTupleStructBuilder<F>
 
     pub fn build(self) -> F::Result {
         let data = ast::VariantData::Tuple(self.fields, ast::DUMMY_NODE_ID);
-        let struct_ = ast::ItemStruct(P(data), self.generics);
+        let struct_ = ast::ItemStruct(data, self.generics);
         self.builder.build_item_(self.id, struct_)
     }
 }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -69,9 +69,10 @@ impl<F> VariantBuilder<F>
         let variant_ = ast::Variant_ {
             name: self.id,
             attrs: self.attrs,
-            data: data,
+            data: data.and_then(|d| d),
             disr_expr: None,
         };
+
         let variant = P(respan(self.span, variant_));
         self.callback.invoke(variant)
     }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -96,7 +96,7 @@ fn test_empty_struct() {
             attrs: vec![],
             id: ast::DUMMY_NODE_ID,
             node: ast::ItemStruct(
-                builder.variant_data().struct_().build(),
+                builder.variant_data().struct_().build().and_then(|x| x),
                 builder.generics().build(),
             ),
             vis: ast::Inherited,
@@ -123,7 +123,7 @@ fn test_struct() {
                 builder.variant_data().struct_()
                     .field("x").ty().isize()
                     .field("y").ty().isize()
-                    .build(),
+                    .build().and_then(|x| x),
                 builder.generics().build(),
             ),
             vis: ast::Inherited,
@@ -171,7 +171,7 @@ fn test_tuple_struct() {
                 builder.variant_data().tuple()
                     .ty().isize()
                     .ty().isize()
-                    .build(),
+                    .build().and_then(|x| x),
                 builder.generics().build(),
             ),
             vis: ast::Inherited,
@@ -398,7 +398,7 @@ fn test_attr() {
                 builder.variant_data().struct_()
                     .field("x").ty().isize()
                     .field("y").ty().isize()
-                    .build(),
+                    .build().and_then(|x| x),
                 builder.generics().build(),
             ),
             vis: ast::Inherited,

--- a/tests/test_variant.rs
+++ b/tests/test_variant.rs
@@ -16,7 +16,7 @@ fn test_unit_variant() {
             node: ast::Variant_ {
                 name: builder.id("A"),
                 attrs: vec![],
-                data: builder.variant_data().unit(),
+                data: builder.variant_data().unit().and_then(|x| x),
                 disr_expr: None,
             },
         })
@@ -41,7 +41,7 @@ fn test_tuple_variant() {
                 data: builder.variant_data().tuple()
                     .ty().isize()
                     .ty().isize()
-                    .build(),
+                    .build().and_then(|x| x),
                 disr_expr: None,
             },
         })
@@ -66,7 +66,7 @@ fn test_struct_variant() {
                 data: builder.variant_data().struct_()
                     .field("a").ty().isize()
                     .field("b").ty().isize()
-                    .build(),
+                    .build().and_then(|x| x),
                 disr_expr: None,
             },
         })


### PR DESCRIPTION
fixes #45

Credits to @Manishearth for the [initial fixup](https://github.com/serde-rs/aster/pull/46), I simply finished the work and ensured the tests were compiling.

`p.and_then(|x| x)` isn't exactly a pretty way to move out of the P<T> struct, but it's the only one I found.
