### PR TITLE
Rustup to rustc 1.6.0-dev (74185aff2 2015-11-05)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A libsyntax ast builder"

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -53,11 +53,7 @@ impl<F> PatBuilder<F>
     }
 
     pub fn wild(self) -> F::Result {
-        self.build_pat_(ast::Pat_::PatWild(ast::PatWildKind::PatWildSingle))
-    }
-
-    pub fn wild_multi(self) -> F::Result {
-        self.build_pat_(ast::Pat_::PatWild(ast::PatWildKind::PatWildMulti))
+        self.build_pat_(ast::Pat_::PatWild)
     }
 
     pub fn build_id<I>(self, mode: ast::BindingMode, id: I, sub: Option<P<ast::Pat>>) -> F::Result


### PR DESCRIPTION
Sadly Rust nightlies haven't been published for the past few days, so this might not compile on nightly till that happens

r? @erickt

Needs https://github.com/serde-rs/syntex/pull/19
