### PR TITLE
Update for libsyntax changes

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -947,7 +947,7 @@ impl<F> ItemImplItemBuilder<F>
         MacBuilder::with_callback(self)
     }
 
-    pub fn build_item(self, node: ast::ImplItem_) -> F::Result {
+    pub fn build_item(self, node: ast::ImplItemKind) -> F::Result {
         let item = ast::ImplItem {
             id: ast::DUMMY_NODE_ID,
             ident: self.id,
@@ -976,7 +976,7 @@ impl<F> Invoke<Const> for ItemImplItemBuilder<F>
     type Result = F::Result;
 
     fn invoke(self, const_: Const) -> F::Result {
-        let node = ast::ConstImplItem(const_.ty, const_.expr.expect("an expr is required for a const impl item"));
+        let node = ast::ImplItemKind::Const(const_.ty, const_.expr.expect("an expr is required for a const impl item"));
         self.build_item(node)
     }
 }
@@ -987,7 +987,7 @@ impl<F> Invoke<Method> for ItemImplItemBuilder<F>
     type Result = F::Result;
 
     fn invoke(self, method: Method) -> F::Result {
-        let node = ast::MethodImplItem(method.sig, method.block.expect("a block is required for a method impl item"));
+        let node = ast::ImplItemKind::Method(method.sig, method.block.expect("a block is required for a method impl item"));
         self.build_item(node)
     }
 }
@@ -998,7 +998,7 @@ impl<F> Invoke<P<ast::Ty>> for ItemImplItemBuilder<F>
     type Result = F::Result;
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
-        let node = ast::TypeImplItem(ty);
+        let node = ast::ImplItemKind::Type(ty);
         self.build_item(node)
     }
 }
@@ -1009,7 +1009,7 @@ impl<F> Invoke<ast::Mac> for ItemImplItemBuilder<F>
     type Result = F::Result;
 
     fn invoke(self, mac: ast::Mac) -> F::Result {
-        let node = ast::MacImplItem(mac);
+        let node = ast::ImplItemKind::Macro(mac);
         self.build_item(node)
     }
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -542,7 +542,7 @@ fn test_impl() {
                         ident: builder.id("MyFloat"),
                         vis: ast::Visibility::Inherited,
                         attrs: vec![],
-                        node: ast::TypeImplItem(builder.ty().f64()),
+                        node: ast::ImplItemKind::Type(builder.ty().f64()),
                         span: DUMMY_SP,
                     }),
 
@@ -551,7 +551,7 @@ fn test_impl() {
                         ident: builder.id("PI"),
                         vis: ast::Visibility::Inherited,
                         attrs: vec![],
-                        node: ast::ConstImplItem(
+                        node: ast::ImplItemKind::Const(
                             builder.ty().f64(),
                             builder.expr().f64("3.14159265358979323846264338327950288"),
                         ),
@@ -563,7 +563,7 @@ fn test_impl() {
                         ident: builder.id("serialize"),
                         vis: ast::Visibility::Inherited,
                         attrs: vec![],
-                        node: ast::MethodImplItem(
+                        node: ast::ImplItemKind::Method(
                             ast::MethodSig {
                                 unsafety: ast::Unsafety::Normal,
                                 constness: ast::Constness::NotConst,


### PR DESCRIPTION
`ast::ImplItem_` was changed to `ast::ImplItemKind`.  This commit changes the relevant code (and tests), and fixes #52 .
