### PR TITLE
Added IndexExpr and RepeatExpr support

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -455,3 +455,41 @@ fn test_match() {
         )
     );
 }
+
+#[test]
+fn test_index() {
+    let builder = AstBuilder::new();
+
+    let expr = builder.expr().index()
+        .id("x")
+        .usize(2);
+
+    assert_eq!(
+        expr,
+        builder.expr().build_expr_(
+            ast::ExprIndex(
+                builder.expr().id("x"),
+                builder.expr().usize(2)
+            )
+        )
+    );
+}
+ 
+#[test]
+fn test_repeat() {
+    let builder = AstBuilder::new();
+
+    let expr = builder.expr().repeat()
+        .u16(1024)
+        .usize(16);
+
+    assert_eq!(
+        expr,
+        builder.expr().build_expr_(
+            ast::ExprRepeat(
+                builder.expr().u16(1024),
+                builder.expr().usize(16)
+            )
+        )
+    );
+}


### PR DESCRIPTION
Firstly, thanks for this great library. It's been a lot of fun learning about the Rust AST and this has made playing with it a lot less painful :) 

This PR adds support for repeat and index expressions, such as:

``` rust
// Repeat expression
let x = [0; 10];

// Index expression
let y = x[5];
```

Example of usage:

``` rust
let builder = AstBuilder::new();

let index_expr = builder.expr().index()
                     .id("x").usize(2); // x[2]

let repeat_expr = builder.expr().repeat()
                     .u16(1024).usize(16); // [1024u16; 16]
```
