### PR TITLE
Fix: #72 replace StructFieldKind

### DIFF
--- a/tests/test_struct_field.rs
+++ b/tests/test_struct_field.rs
@@ -10,18 +10,14 @@ fn test_named() {
 
     assert_eq!(
         builder.struct_field("x").ty().isize(),
-        respan(
-            DUMMY_SP,
-            ast::StructField_ {
-                kind: ast::NamedField(
-                    builder.id("x"),
-                    ast::Visibility::Inherited,
-                ),
-                id: ast::DUMMY_NODE_ID,
-                ty: builder.ty().isize(),
-                attrs: vec![],
-            },
-        )
+        ast::StructField {
+            ident: Some(builder.id("x")),
+            vis: ast::Visibility::Inherited,
+            id: ast::DUMMY_NODE_ID,
+            ty: builder.ty().isize(),
+            attrs: vec![],
+            span: DUMMY_SP
+        }
     );
 }
 
@@ -31,15 +27,14 @@ fn test_unnamed() {
 
     assert_eq!(
         builder.tuple_field().ty().isize(),
-        respan(
-            DUMMY_SP,
-            ast::StructField_ {
-                kind: ast::UnnamedField(ast::Visibility::Inherited),
-                id: ast::DUMMY_NODE_ID,
-                ty: builder.ty().isize(),
-                attrs: vec![],
-            },
-        )
+        ast::StructField {
+            ident: None,
+            vis: ast::Visibility::Inherited,
+            id: ast::DUMMY_NODE_ID,
+            ty: builder.ty().isize(),
+            attrs: vec![],
+            span: DUMMY_SP
+        }
     );
 }
 
@@ -52,45 +47,41 @@ fn test_attrs() {
             .attr().doc("/// doc string")
             .attr().automatically_derived()
             .ty().isize(),
-        respan(
-            DUMMY_SP,
-            ast::StructField_ {
-                kind: ast::NamedField(
-                    builder.id("x"),
-                    ast::Visibility::Inherited,
+        ast::StructField {
+            ident: Some(builder.id("x")),
+            vis: ast::Visibility::Inherited,
+            id: ast::DUMMY_NODE_ID,
+            ty: builder.ty().isize(),
+            span: DUMMY_SP,
+            attrs: vec![
+                respan(
+                    DUMMY_SP,
+                    ast::Attribute_ {
+                        id: ast::AttrId(0),
+                        style: ast::AttrStyle::Outer,
+                        value: P(respan(
+                            DUMMY_SP,
+                            ast::MetaItemKind::NameValue(
+                                builder.interned_string("doc"),
+                                (*builder.lit().str("/// doc string")).clone(),
+                            ),
+                        )),
+                        is_sugared_doc: true,
+                    }
                 ),
-                id: ast::DUMMY_NODE_ID,
-                ty: builder.ty().isize(),
-                attrs: vec![
-                    respan(
-                        DUMMY_SP,
-                        ast::Attribute_ {
-                            id: ast::AttrId(0),
-                            style: ast::AttrStyle::Outer,
-                            value: P(respan(
-                                DUMMY_SP,
-                                ast::MetaItemKind::NameValue(
-                                    builder.interned_string("doc"),
-                                    (*builder.lit().str("/// doc string")).clone(),
-                                ),
-                            )),
-                            is_sugared_doc: true,
-                        }
-                    ),
-                    respan(
-                        DUMMY_SP,
-                        ast::Attribute_ {
-                            id: ast::AttrId(1),
-                            style: ast::AttrStyle::Outer,
-                            value: P(respan(
-                                DUMMY_SP,
-                                ast::MetaItemKind::Word(builder.interned_string("automatically_derived")),
-                            )),
-                            is_sugared_doc: false,
-                        }
-                    ),
-                ],
-            },
-        )
+                respan(
+                    DUMMY_SP,
+                    ast::Attribute_ {
+                        id: ast::AttrId(1),
+                        style: ast::AttrStyle::Outer,
+                        value: P(respan(
+                            DUMMY_SP,
+                            ast::MetaItemKind::Word(builder.interned_string("automatically_derived")),
+                        )),
+                        is_sugared_doc: false,
+                    }
+                ),
+            ],
+        }
     );
 }


### PR DESCRIPTION
Fixes #72 

Note there are a few things I probably don't have right because I'm not sure what the `aster` approach is:
- I'm not sure what `respan` is all about, so I took it out because it was complaining about a type mismatch. Should the output of `builder.struct_field` be `Spanned<T>`? 
- I'm not sure what `ToIdent` is all about either, and builder structs in `aster` don't have explicit idents on them. Does this have something to do with the `F` generic parameter?

If someone can point me in the right direction I'll fix these up properly.
