### PR TITLE
Update for latest libsyntax changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A libsyntax ast builder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ with-syntex = ["syntex_syntax"]
 unstable-testing = ["clippy", "compiletest_rs"]
 
 [dependencies]
-syntex_syntax = { version = "^0.31.0", optional = true }
+syntex_syntax = { version = "^0.32.0", optional = true }
 clippy = { version = "0.*", optional = true }
 compiletest_rs = { version = "^0.1.1", optional = true }
 

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -57,7 +57,7 @@ impl<F> GenericsBuilder<F>
 
     pub fn with(self, generics: ast::Generics) -> Self {
         self.with_lifetimes(generics.lifetimes.into_iter())
-            .with_ty_params(generics.ty_params.move_iter())
+            .with_ty_params(generics.ty_params.into_iter())
             .with_predicates(generics.where_clause.predicates.into_iter())
     }
 
@@ -200,7 +200,7 @@ impl<F> GenericsBuilder<F>
 
     pub fn strip_ty_params(mut self) -> Self {
         for ty_param in &mut self.ty_params {
-            ty_param.bounds = P::empty();
+            ty_param.bounds = P::new();
         }
         self
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -111,7 +111,7 @@ impl<F> ItemBuilder<F>
 
     pub fn build_use(self, view_path: ast::ViewPath_) -> F::Result {
         let item = ast::ItemKind::Use(P(respan(self.span, view_path)));
-        self.build_item_kind(token::special_idents::invalid, item)
+        self.build_item_kind(token::keywords::Invalid.ident(), item)
     }
 
     pub fn use_(self) -> PathBuilder<ItemUseBuilder<F>> {
@@ -1180,7 +1180,7 @@ impl<F> ItemImplBuilder<F>
             self.trait_ref,
             ty,
             self.items);
-        self.builder.build_item_kind(token::special_idents::invalid, ty_)
+        self.builder.build_item_kind(token::keywords::Invalid.ident(), ty_)
     }
 
     pub fn with_items<I>(mut self, items: I) -> Self

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -12,7 +12,7 @@ fn test_empty() {
         generics,
         ast::Generics {
             lifetimes: vec![],
-            ty_params: P::empty(),
+            ty_params: P::new(),
             where_clause: ast::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: vec![],

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -268,7 +268,7 @@ fn test_use() {
         assert_eq!(
             item,
             P(ast::Item {
-                ident: token::special_idents::invalid,
+                ident: token::keywords::Invalid.ident(),
                 attrs: vec![],
                 id: ast::DUMMY_NODE_ID,
                 node: ast::ItemKind::Use(

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -110,7 +110,7 @@ fn test_option() {
                         types: P::from_vec(vec![
                             builder.ty().isize(),
                         ]),
-                        bindings: P::empty(),
+                        bindings: P::new(),
                     }),
                 },
             ]
@@ -139,8 +139,8 @@ fn test_lifetimes() {
                         lifetimes: vec![
                             builder.lifetime("'a"),
                         ],
-                        types: P::empty(),
-                        bindings: P::empty(),
+                        types: P::new(),
+                        bindings: P::new(),
                     }),
                 },
             ]

--- a/tests/test_ty_param.rs
+++ b/tests/test_ty_param.rs
@@ -16,7 +16,7 @@ fn test_ty_param_empty() {
         ast::TyParam {
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
-            bounds: P::empty(),
+            bounds: P::new(),
             default: None,
             span: DUMMY_SP,
         }
@@ -36,7 +36,7 @@ fn test_ty_param_default() {
         ast::TyParam {
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
-            bounds: P::empty(),
+            bounds: P::new(),
             default: Some(builder.ty().usize()),
             span: DUMMY_SP,
         }


### PR DESCRIPTION
Adapt to the changed interfaces, and bump the version number.

This builds on the updated `syntex` from https://github.com/serde-rs/syntex/pull/44 , so it works on stable Rust too.
