### PR TITLE
Started using the DummyMacroLoader as per the latest nightly

### DIFF
--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,6 +1,6 @@
 use syntax::ast;
 use syntax::codemap::{self, DUMMY_SP, Span, respan};
-use syntax::ext::base::ExtCtxt;
+use syntax::ext::base::{ExtCtxt, DummyMacroLoader, MacroLoader};
 use syntax::ext::expand;
 use syntax::ext::quote::rt::ToTokens;
 use syntax::feature_gate::GatedCfgAttr;
@@ -72,7 +72,8 @@ impl<F> MacBuilder<F>
     {
         let parse_sess = ParseSess::new();
         let mut feature_gated_cfgs = Vec::new();
-        let cx = make_ext_ctxt(&parse_sess, &mut feature_gated_cfgs);
+        let mut macro_loader = DummyMacroLoader;
+        let cx = make_ext_ctxt(&parse_sess, &mut feature_gated_cfgs, &mut macro_loader);
         let tokens = expr.to_tokens(&cx);
         assert!(tokens.len() == 1);
         self.tokens.push(tokens[0].clone());
@@ -96,7 +97,8 @@ impl<F> Invoke<P<ast::Expr>> for MacBuilder<F>
 }
 
 fn make_ext_ctxt<'a>(sess: &'a ParseSess,
-                     feature_gated_cfgs: &'a mut Vec<GatedCfgAttr>) -> ExtCtxt<'a> {
+                     feature_gated_cfgs: &'a mut Vec<GatedCfgAttr>,
+                     macro_loader: &'a mut MacroLoader) -> ExtCtxt<'a> {
     let info = codemap::ExpnInfo {
         call_site: codemap::DUMMY_SP,
         callee: codemap::NameAndSpan {
@@ -109,7 +111,7 @@ fn make_ext_ctxt<'a>(sess: &'a ParseSess,
     let cfg = vec![];
     let ecfg = expand::ExpansionConfig::default(String::new());
 
-    let mut cx = ExtCtxt::new(sess, cfg, ecfg, feature_gated_cfgs);
+    let mut cx = ExtCtxt::new(sess, cfg, ecfg, feature_gated_cfgs, macro_loader);
     cx.bt_push(info);
 
     cx


### PR DESCRIPTION
Latest rust introduced the concept of a "MacroLoader", I don't know what it does, but it's just a new argument to ExtCtxt::new, all the prior arguments remain the same. And they provide a DummyMacroLoader which seems to be a conveniente backwards compatible placeholder.

I'm not too experienced with this but I'm very close to releasing decimal support for serde/serde_json and it all depends on these other crates.

Hope this helps.
