### PR TITLE
Propagate spans through calls

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -221,7 +221,8 @@ impl<F> ArmBodyBuilder<F>
     where F: Invoke<ast::Arm>,
 {
     pub fn body(self) -> ExprBuilder<ArmBodyBuilder<F>> {
-        ExprBuilder::with_callback(self)
+        let span = self.builder.span;
+        ExprBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self, body: P<ast::Expr>) -> F::Result {

--- a/src/block.rs
+++ b/src/block.rs
@@ -59,7 +59,8 @@ impl<F> BlockBuilder<F>
     }
 
     pub fn stmt(self) -> StmtBuilder<Self> {
-        StmtBuilder::with_callback(self)
+        let span = self.span;
+        StmtBuilder::with_callback(self).span(span)
     }
 
     pub fn build_expr(self, expr: P<ast::Expr>) -> F::Result {
@@ -67,7 +68,8 @@ impl<F> BlockBuilder<F>
     }
 
     pub fn expr(self) -> ExprBuilder<Self> {
-        ExprBuilder::with_callback(self)
+        let span = self.span;
+        ExprBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -76,7 +78,7 @@ impl<F> BlockBuilder<F>
 
     fn build_(mut self, expr: Option<P<ast::Expr>>) -> F::Result {
         self.stmts.extend(expr.map(|expr| {
-            StmtBuilder::new().build_expr(expr)
+            StmtBuilder::new().span(expr.span).build_expr(expr)
         }));
         self.callback.invoke(P(ast::Block {
             stmts: self.stmts,

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -55,7 +55,8 @@ impl<F> ConstBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self, ty: P<ast::Ty>) -> F::Result {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -80,11 +80,13 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn path(self) -> PathBuilder<Self> {
-        PathBuilder::with_callback(self)
+        let span = self.span;
+        PathBuilder::with_callback(self).span(span)
     }
 
     pub fn qpath(self) -> QPathBuilder<Self> {
-        QPathBuilder::with_callback(self)
+        let span = self.span;
+        QPathBuilder::with_callback(self).span(span)
     }
 
     pub fn id<I>(self, id: I) -> F::Result
@@ -220,10 +222,11 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn unary(self, unop: ast::UnOp) -> ExprBuilder<ExprUnaryBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprUnaryBuilder {
             builder: self,
             unop: unop,
-        })
+        }).span(span)
     }
 
     pub fn deref(self) -> ExprBuilder<ExprUnaryBuilder<F>> {
@@ -319,10 +322,11 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn binary(self, binop: ast::BinOpKind) -> ExprBuilder<ExprBinaryLhsBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprBinaryLhsBuilder {
             builder: self,
             binop: binop,
-        })
+        }).span(span)
     }
 
     pub fn add(self) -> ExprBuilder<ExprBinaryLhsBuilder<F>> {
@@ -398,17 +402,19 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn ref_(self) -> ExprBuilder<ExprRefBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprRefBuilder {
             builder: self,
             mutability: ast::Mutability::Immutable,
-        })
+        }).span(span)
     }
 
     pub fn mut_ref(self) -> ExprBuilder<ExprRefBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprRefBuilder {
             builder: self,
             mutability: ast::Mutability::Mutable,
-        })
+        }).span(span)
     }
 
     pub fn break_(self) -> F::Result {
@@ -438,9 +444,10 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn return_expr(self) -> ExprBuilder<ExprReturnBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprReturnBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn unit(self) -> F::Result {
@@ -492,38 +499,44 @@ impl<F> ExprBuilder<F>
 
     pub fn some(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("option").id("Option").id("Some")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn ok(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("result").id("Result").id("Ok")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn err(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("result").id("Result").id("Err")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn phantom_data(self) -> F::Result {
@@ -534,19 +547,23 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn call(self) -> ExprBuilder<ExprCallBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprCallBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn method_call<I>(self, id: I) -> ExprBuilder<ExprMethodCallBuilder<F>>
         where I: ToIdent,
     {
         let id = respan(self.span, id.to_ident());
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprMethodCallBuilder {
             builder: self,
             id: id,
-        })
+        }).span(span)
     }
 
     pub fn build_block(self, block: P<ast::Block>) -> F::Result {
@@ -562,9 +579,11 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn assign(self) -> ExprBuilder<ExprAssignBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprAssignBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn build_assign_op(self,
@@ -576,10 +595,12 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn assign_op(self, binop: ast::BinOpKind) -> ExprBuilder<ExprAssignOpBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprAssignOpBuilder {
             builder: self,
             binop: binop,
-        })
+        }).span(span)
     }
 
     pub fn add_assign(self) -> ExprBuilder<ExprAssignOpBuilder<F>> {
@@ -631,9 +652,11 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn index(self) -> ExprBuilder<ExprIndexBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprIndexBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn build_repeat(self, lhs: P<ast::Expr>, rhs: P<ast::Expr>) -> F::Result {
@@ -641,9 +664,11 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn repeat(self) -> ExprBuilder<ExprRepeatBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprRepeatBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn loop_(self) -> ExprLoopBuilder<F> {
@@ -657,79 +682,95 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn if_(self) -> ExprBuilder<ExprIfBuilder<F>> {
+        let span = self.span;
         ExprBuilder::with_callback(ExprIfBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn match_(self) -> ExprBuilder<ExprMatchBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprMatchBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn paren(self) -> ExprBuilder<ExprParenBuilder<F>> {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprParenBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn field<I>(self, id: I) -> ExprBuilder<ExprFieldBuilder<F>>
         where I: ToIdent,
     {
         let id = respan(self.span, id.to_ident());
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprFieldBuilder {
             builder: self,
             id: id,
-        })
+        }).span(span)
     }
 
     pub fn tup_field(self, index: usize) -> ExprBuilder<ExprTupFieldBuilder<F>> {
         let index = respan(self.span, index);
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprTupFieldBuilder {
             builder: self,
             index: index,
-        })
+        }).span(span)
     }
 
     pub fn box_(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("boxed").id("Box").id("new")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn rc(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("rc").id("Rc").id("new")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn arc(self) -> ExprBuilder<ExprPathBuilder<F>> {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .id("std").id("arc").id("Arc").id("new")
             .build();
+        let span = self.span;
 
         ExprBuilder::with_callback(ExprPathBuilder {
             builder: self,
             path: path,
-        })
+        }).span(span)
     }
 
     pub fn default(self) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.span)
             .global()
             .ids(&["std", "default", "Default", "default"])
             .build();
@@ -972,10 +1013,12 @@ impl<F> ExprStructPathBuilder<F>
     pub fn field<I>(self, id: I) -> ExprBuilder<ExprStructFieldBuilder<I, F>>
         where I: ToIdent,
     {
+        let span = self.span;
+
         ExprBuilder::with_callback(ExprStructFieldBuilder {
             builder: self,
             id: id,
-        })
+        }).span(span)
     }
 
     pub fn build_with(self) -> ExprBuilder<Self> {
@@ -1065,7 +1108,8 @@ impl<F> ExprCallArgsBuilder<F>
     }
 
     pub fn arg(self) -> ExprBuilder<Self> {
-        ExprBuilder::with_callback(self)
+        let span = self.builder.span;
+        ExprBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -1130,7 +1174,8 @@ impl<F> ExprMethodCallArgsBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn with_args<I>(mut self, iter: I) -> Self
@@ -1146,7 +1191,8 @@ impl<F> ExprMethodCallArgsBuilder<F>
     }
 
     pub fn arg(self) -> ExprBuilder<Self> {
-        ExprBuilder::with_callback(self)
+        let span = self.builder.span;
+        ExprBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -1223,10 +1269,11 @@ impl<F> Invoke<P<ast::Expr>> for ExprAssignBuilder<F>
     type Result = ExprBuilder<ExprAssignLhsBuilder<F>>;
 
     fn invoke(self, lhs: P<ast::Expr>) -> ExprBuilder<ExprAssignLhsBuilder<F>> {
+        let span = self.builder.span;
         ExprBuilder::with_callback(ExprAssignLhsBuilder {
             builder: self.builder,
             lhs: lhs,
-        })
+        }).span(span)
     }
 }
 
@@ -1260,11 +1307,12 @@ impl<F> Invoke<P<ast::Expr>> for ExprAssignOpBuilder<F>
     type Result = ExprBuilder<ExprAssignOpLhsBuilder<F>>;
 
     fn invoke(self, lhs: P<ast::Expr>) -> ExprBuilder<ExprAssignOpLhsBuilder<F>> {
+        let span = self.builder.span;
         ExprBuilder::with_callback(ExprAssignOpLhsBuilder {
             builder: self.builder,
             binop: self.binop,
             lhs: lhs,
-        })
+        }).span(span)
     }
 }
 
@@ -1298,10 +1346,11 @@ impl<F> Invoke<P<ast::Expr>> for ExprIndexBuilder<F>
     type Result = ExprBuilder<ExprIndexLhsBuilder<F>>;
 
     fn invoke(self, lhs: P<ast::Expr>) -> ExprBuilder<ExprIndexLhsBuilder<F>> {
+        let span = self.builder.span;
         ExprBuilder::with_callback(ExprIndexLhsBuilder {
             builder: self.builder,
             lhs: lhs,
-        })
+        }).span(span)
     }
 }
 
@@ -1334,10 +1383,11 @@ impl<F> Invoke<P<ast::Expr>> for ExprRepeatBuilder<F>
     type Result = ExprBuilder<ExprRepeatLhsBuilder<F>>;
 
     fn invoke(self, lhs: P<ast::Expr>) -> ExprBuilder<ExprRepeatLhsBuilder<F>> {
+        let span = self.builder.span;
         ExprBuilder::with_callback(ExprRepeatLhsBuilder {
             builder: self.builder,
             lhs: lhs,
-        })
+        }).span(span)
     }
 }
 
@@ -1462,9 +1512,10 @@ impl<F> ExprIfThenElseBuilder<F>
     where F: Invoke<P<ast::Expr>>,
 {
     pub fn else_if(self) -> ExprBuilder<ExprElseIfBuilder<F>> {
+        let span = self.builder.span;
         ExprBuilder::with_callback(ExprElseIfBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 
     fn build_else_expr(self, mut else_: P<ast::Expr>) -> F::Result {
@@ -1702,7 +1753,8 @@ impl<F: Invoke<P<ast::Expr>>> ExprSliceBuilder<F>
     }
 
     pub fn expr(self) -> ExprBuilder<Self> {
-        ExprBuilder::with_callback(self)
+        let span = self.builder.span;
+        ExprBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -1757,6 +1809,7 @@ impl<F> Invoke<P<ast::Expr>> for ExprTryBuilder<F>
 
     fn invoke(self, expr: P<ast::Expr>) -> F::Result {
         let ok_path = PathBuilder::new()
+            .span(self.builder.span)
             .global()
             .ids(&["std", "result", "Result", "Ok"])
             .build();
@@ -1772,6 +1825,7 @@ impl<F> Invoke<P<ast::Expr>> for ExprTryBuilder<F>
                 .id("value");
 
         let err_path = PathBuilder::new()
+            .span(self.builder.span)
             .global()
             .ids(&["std", "result", "Result", "Err"])
             .build();

--- a/src/fn_decl.rs
+++ b/src/fn_decl.rs
@@ -109,7 +109,8 @@ impl<F> FnDeclBuilder<F>
     }
 
     pub fn return_(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self, output: ast::FunctionRetTy) -> F::Result {

--- a/src/item.rs
+++ b/src/item.rs
@@ -162,7 +162,8 @@ impl<F> ItemBuilder<F>
         where T: ToIdent,
     {
         let id = id.to_ident();
-        let generics = GenericsBuilder::new().build();
+        let span = self.span;
+        let generics = GenericsBuilder::new().span(span).build();
 
         ItemEnumBuilder {
             builder: self,
@@ -536,7 +537,8 @@ impl<F> ItemTupleStructBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn field(self) -> StructFieldBuilder<Self> {
@@ -596,7 +598,8 @@ impl<F> ItemEnumBuilder<F>
     where F: Invoke<P<ast::Item>>,
 {
     pub fn generics(self) -> GenericsBuilder<Self> {
-        GenericsBuilder::with_callback(self)
+        let span = self.builder.span;
+        GenericsBuilder::with_callback(self).span(span)
     }
 
     pub fn with_variants<I>(mut self, iter: I) -> Self
@@ -647,7 +650,8 @@ impl<F> ItemEnumBuilder<F>
     pub fn variant<T>(self, id: T) -> VariantBuilder<Self>
         where T: ToIdent,
     {
-        VariantBuilder::with_callback(id, self)
+        let span = self.builder.span;
+        VariantBuilder::with_callback(id, self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -761,7 +765,8 @@ impl<F> ItemTyBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build_ty(self, ty: P<ast::Ty>) -> F::Result {
@@ -1098,7 +1103,8 @@ impl<F> ItemTraitTypeBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -1169,7 +1175,8 @@ impl<F> ItemImplBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build_ty(self, ty: P<ast::Ty>) -> F::Result {
@@ -1346,7 +1353,8 @@ impl<F> ItemImplItemBuilder<F>
     }
 
     pub fn type_(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn mac(self) -> MacBuilder<Self> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,19 +85,19 @@ impl AstBuilder {
     }
 
     pub fn arm(&self) -> arm::ArmBuilder {
-        arm::ArmBuilder::new()
+        arm::ArmBuilder::new().span(self.span)
     }
 
     pub fn attr(&self) -> attr::AttrBuilder {
-        attr::AttrBuilder::new()
+        attr::AttrBuilder::new().span(self.span)
     }
 
     pub fn path(&self) -> path::PathBuilder {
-        path::PathBuilder::new()
+        path::PathBuilder::new().span(self.span)
     }
 
     pub fn qpath(&self) -> qpath::QPathBuilder {
-        qpath::QPathBuilder::new()
+        qpath::QPathBuilder::new().span(self.span)
     }
 
     pub fn ty(&self) -> ty::TyBuilder {

--- a/src/path.rs
+++ b/src/path.rs
@@ -149,7 +149,8 @@ impl<F> PathSegmentsBuilder<F>
     pub fn segment<T>(self, id: T) -> PathSegmentBuilder<Self>
         where T: ToIdent,
     {
-        PathSegmentBuilder::with_callback(id, self)
+        let span = self.span;
+        PathSegmentBuilder::with_callback(id, self).span(span)
     }
 
     pub fn build(self) -> F::Result {
@@ -207,8 +208,10 @@ impl<F> PathSegmentBuilder<F>
         let lifetimes = generics.lifetimes.iter()
             .map(|lifetime_def| lifetime_def.lifetime);
 
+        let span = self.span;
+
         let tys = generics.ty_params.iter()
-            .map(|ty_param| TyBuilder::new().id(ty_param.ident));
+            .map(|ty_param| TyBuilder::new().span(span).id(ty_param.ident));
 
         self.with_lifetimes(lifetimes)
             .with_tys(tys)
@@ -254,7 +257,8 @@ impl<F> PathSegmentBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn with_binding(mut self, binding: ast::TypeBinding) -> Self {
@@ -265,10 +269,11 @@ impl<F> PathSegmentBuilder<F>
     pub fn binding<T>(self, id: T) -> TyBuilder<TypeBindingBuilder<F>>
         where T: ToIdent,
     {
+        let span = self.span;
         TyBuilder::with_callback(TypeBindingBuilder {
             id: id.to_ident(),
             builder: self,
-        })
+        }).span(span)
     }
 
     pub fn build(self) -> F::Result {

--- a/src/qpath.rs
+++ b/src/qpath.rs
@@ -51,7 +51,8 @@ impl<F> QPathBuilder<F>
 
     /// Build a qualified path first by starting with a type builder.
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     /// Build a qualified path with a concrete type and path.
@@ -82,7 +83,8 @@ impl<F> QPathTyBuilder<F>
 {
     /// Build a qualified path with a path builder.
     pub fn as_(self) -> PathBuilder<Self> {
-        PathBuilder::with_callback(self)
+        let span = self.builder.span;
+        PathBuilder::with_callback(self).span(span)
     }
 
     pub fn id<T>(self, id: T) -> F::Result

--- a/src/self_.rs
+++ b/src/self_.rs
@@ -64,7 +64,8 @@ impl<F> SelfBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 }
 

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -178,7 +178,8 @@ impl<F> StmtLetBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build_expr(self, expr: P<ast::Expr>) -> F::Result {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -143,7 +143,8 @@ impl<F> TyBuilder<F>
     }
 
     pub fn slice(self) -> TyBuilder<TySliceBuilder<F>> {
-        TyBuilder::with_callback(TySliceBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TySliceBuilder(self)).span(span)
     }
 
     pub fn ref_(self) -> TyRefBuilder<F> {
@@ -159,29 +160,35 @@ impl<F> TyBuilder<F>
     }
 
     pub fn option(self) -> TyBuilder<TyOptionBuilder<F>> {
-        TyBuilder::with_callback(TyOptionBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TyOptionBuilder(self)).span(span)
     }
 
     pub fn result(self) -> TyBuilder<TyResultOkBuilder<F>> {
-        TyBuilder::with_callback(TyResultOkBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TyResultOkBuilder(self)).span(span)
     }
 
     pub fn phantom_data(self) -> TyBuilder<TyPhantomDataBuilder<F>> {
-        TyBuilder::with_callback(TyPhantomDataBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TyPhantomDataBuilder(self)).span(span)
     }
 
     pub fn box_(self) -> TyBuilder<TyBoxBuilder<F>> {
-        TyBuilder::with_callback(TyBoxBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TyBoxBuilder(self)).span(span)
     }
 
     pub fn iterator(self) -> TyBuilder<TyIteratorBuilder<F>> {
-        TyBuilder::with_callback(TyIteratorBuilder(self))
+        let span = self.span;
+        TyBuilder::with_callback(TyIteratorBuilder(self)).span(span)
     }
 
     pub fn object_sum(self) -> TyBuilder<TyObjectSumBuilder<F>> {
+        let span = self.span;
         TyBuilder::with_callback(TyObjectSumBuilder {
             builder: self,
-        })
+        }).span(span)
     }
 }
 
@@ -263,7 +270,8 @@ impl<F> TyRefBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 }
 
@@ -288,6 +296,7 @@ impl<F> Invoke<P<ast::Ty>> for TyOptionBuilder<F>
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.0.span)
             .global()
             .id("std")
             .id("option")
@@ -310,7 +319,8 @@ impl<F> Invoke<P<ast::Ty>> for TyResultOkBuilder<F>
     type Result = TyBuilder<TyResultErrBuilder<F>>;
 
     fn invoke(self, ty: P<ast::Ty>) -> TyBuilder<TyResultErrBuilder<F>> {
-        TyBuilder::with_callback(TyResultErrBuilder(self.0, ty))
+        let span = self.0.span;
+        TyBuilder::with_callback(TyResultErrBuilder(self.0, ty)).span(span)
     }
 }
 
@@ -323,6 +333,7 @@ impl<F> Invoke<P<ast::Ty>> for TyResultErrBuilder<F>
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.0.span)
             .global()
             .id("std")
             .id("result")
@@ -347,6 +358,7 @@ impl<F> Invoke<P<ast::Ty>> for TyPhantomDataBuilder<F>
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.0.span)
             .global()
             .id("std")
             .id("marker")
@@ -370,6 +382,7 @@ impl<F> Invoke<P<ast::Ty>> for TyBoxBuilder<F>
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.0.span)
             .global()
             .id("std")
             .id("boxed")
@@ -393,6 +406,7 @@ impl<F> Invoke<P<ast::Ty>> for TyIteratorBuilder<F>
 
     fn invoke(self, ty: P<ast::Ty>) -> F::Result {
         let path = PathBuilder::new()
+            .span(self.0.span)
             .global()
             .id("std")
             .id("iter")
@@ -513,7 +527,8 @@ impl<F> TyTupleBuilder<F>
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.builder.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build(self) -> F::Result {

--- a/src/ty_param.rs
+++ b/src/ty_param.rs
@@ -67,7 +67,8 @@ impl<F> TyParamBuilder<F>
     }
 
     pub fn default(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn with_bound(mut self, bound: ast::TyParamBound) -> Self {

--- a/src/where_predicate.rs
+++ b/src/where_predicate.rs
@@ -38,7 +38,8 @@ impl<F> WherePredicateBuilder<F>
     }
 
     pub fn bound(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn lifetime<L>(self, lifetime: L) -> WhereRegionPredicateBuilder<F>
@@ -308,7 +309,8 @@ impl<F> WhereEqPredicateBuilder<F>
     where F: Invoke<ast::WherePredicate>,
 {
     pub fn ty(self) -> TyBuilder<Self> {
-        TyBuilder::with_callback(self)
+        let span = self.span;
+        TyBuilder::with_callback(self).span(span)
     }
 
     pub fn build_ty(self, ty: P<ast::Ty>) -> F::Result {


### PR DESCRIPTION
This should fix many errors where spans weren't properly being passed down through chained calls.
