### PR TITLE
Fix build 667.2

### DIFF
--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -41,6 +41,7 @@ impl IntoLifetimeDef for ast::LifetimeDef {
 impl IntoLifetimeDef for ast::Lifetime {
     fn into_lifetime_def(self) -> ast::LifetimeDef {
         ast::LifetimeDef {
+            attrs: ast::ThinVec::new(),
             lifetime: self,
             bounds: vec![],
         }
@@ -109,6 +110,7 @@ impl<F> LifetimeDefBuilder<F>
 
     pub fn build(self) -> F::Result {
         self.callback.invoke(ast::LifetimeDef {
+            attrs: ast::ThinVec::new(),
             lifetime: self.lifetime,
             bounds: self.bounds,
         })

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -38,10 +38,21 @@ impl IntoLifetimeDef for ast::LifetimeDef {
     }
 }
 
+#[cfg(not(feature = "with-syntex"))]
 impl IntoLifetimeDef for ast::Lifetime {
     fn into_lifetime_def(self) -> ast::LifetimeDef {
         ast::LifetimeDef {
             attrs: ast::ThinVec::new(),
+            lifetime: self,
+            bounds: vec![],
+        }
+    }
+}
+
+#[cfg(feature = "with-syntex")]
+impl IntoLifetimeDef for ast::Lifetime {
+    fn into_lifetime_def(self) -> ast::LifetimeDef {
+        ast::LifetimeDef {
             lifetime: self,
             bounds: vec![],
         }
@@ -108,9 +119,18 @@ impl<F> LifetimeDefBuilder<F>
         self
     }
 
+    #[cfg(not(feature = "with-syntex"))]
     pub fn build(self) -> F::Result {
         self.callback.invoke(ast::LifetimeDef {
             attrs: ast::ThinVec::new(),
+            lifetime: self.lifetime,
+            bounds: self.bounds,
+        })
+    }
+
+    #[cfg(feature = "with-syntex")]
+    pub fn build(self) -> F::Result {
+        self.callback.invoke(ast::LifetimeDef {
             lifetime: self.lifetime,
             bounds: self.bounds,
         })

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -144,13 +144,26 @@ impl<F> TyBuilder<F>
         TyBuilder::with_callback(TyArrayBuilder(self, len)).span(span)
     }
 
+    #[cfg(not(feature = "with-syntex"))]
     pub fn build_slice(self, ty: P<ast::Ty>) -> F::Result {
         self.build_ty_kind(ast::TyKind::Slice(ty))
     }
 
+    #[cfg(feature = "with-syntex")]
+    pub fn build_slice(self, ty: P<ast::Ty>) -> F::Result {
+        self.build_ty_kind(ast::TyKind::Vec(ty))
+    }
+
+    #[cfg(not(feature = "with-syntex"))]
     pub fn build_array(self, ty: P<ast::Ty>, len: usize) -> F::Result {
         let len_expr = ExprBuilder::new().usize(len);
         self.build_ty_kind(ast::TyKind::Array(ty, len_expr))
+    }
+
+    #[cfg(feature = "with-syntex")]
+    pub fn build_array(self, ty: P<ast::Ty>, len: usize) -> F::Result {
+        let len_expr = ExprBuilder::new().usize(len);
+        self.build_ty_kind(ast::TyKind::FixedLengthVec(ty, len_expr))
     }
 
     pub fn slice(self) -> TyBuilder<TySliceBuilder<F>> {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -145,12 +145,12 @@ impl<F> TyBuilder<F>
     }
 
     pub fn build_slice(self, ty: P<ast::Ty>) -> F::Result {
-        self.build_ty_kind(ast::TyKind::Vec(ty))
+        self.build_ty_kind(ast::TyKind::Slice(ty))
     }
 
     pub fn build_array(self, ty: P<ast::Ty>, len: usize) -> F::Result {
         let len_expr = ExprBuilder::new().usize(len);
-        self.build_ty_kind(ast::TyKind::FixedLengthVec(ty, len_expr))
+        self.build_ty_kind(ast::TyKind::Array(ty, len_expr))
     }
 
     pub fn slice(self) -> TyBuilder<TySliceBuilder<F>> {

--- a/src/ty_param.rs
+++ b/src/ty_param.rs
@@ -101,6 +101,7 @@ impl<F> TyParamBuilder<F>
 
     pub fn build(self) -> F::Result {
         self.callback.invoke(ast::TyParam {
+            attrs: ast::ThinVec::new(),
             ident: self.id,
             id: ast::DUMMY_NODE_ID,
             bounds: P::from_vec(self.bounds),

--- a/src/ty_param.rs
+++ b/src/ty_param.rs
@@ -99,9 +99,21 @@ impl<F> TyParamBuilder<F>
         self
     }
 
+    #[cfg(not(feature = "with-syntex"))]
     pub fn build(self) -> F::Result {
         self.callback.invoke(ast::TyParam {
             attrs: ast::ThinVec::new(),
+            ident: self.id,
+            id: ast::DUMMY_NODE_ID,
+            bounds: P::from_vec(self.bounds),
+            default: self.default,
+            span: self.span,
+        })
+    }
+
+    #[cfg(feature = "with-syntex")]
+    pub fn build(self) -> F::Result {
+        self.callback.invoke(ast::TyParam {
             ident: self.id,
             id: ast::DUMMY_NODE_ID,
             bounds: P::from_vec(self.bounds),

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -70,6 +70,7 @@ fn test_qpath() {
 }
 
 #[test]
+#[cfg(not(feature = "with-syntex"))]
 fn test_array() {
     let builder = AstBuilder::new();
     let ty = builder.ty().array(3).usize();
@@ -79,6 +80,25 @@ fn test_array() {
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
             node: ast::TyKind::Array(AstBuilder::new().ty().usize(),
+                AstBuilder::new().expr().usize(3)
+            ),
+            span: DUMMY_SP,
+        })
+    );
+
+}
+
+#[test]
+#[cfg(feature = "with-syntex")]
+fn test_array() {
+    let builder = AstBuilder::new();
+    let ty = builder.ty().array(3).usize();
+
+    assert_eq!(
+        ty,
+        P(ast::Ty {
+            id: ast::DUMMY_NODE_ID,
+            node: ast::TyKind::FixedLengthVec(AstBuilder::new().ty().usize(),
                 AstBuilder::new().expr().usize(3)
             ),
             span: DUMMY_SP,
@@ -195,6 +215,7 @@ fn test_tuple() {
 }
 
 #[test]
+#[cfg(not(feature = "with-syntex"))]
 fn test_slice() {
     let builder = AstBuilder::new();
     let ty = builder.ty()
@@ -205,6 +226,23 @@ fn test_slice() {
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
             node: ast::TyKind::Slice(builder.ty().isize()),
+            span: DUMMY_SP,
+        })
+    );
+}
+
+#[test]
+#[cfg(feature = "with-syntex")]
+fn test_slice() {
+    let builder = AstBuilder::new();
+    let ty = builder.ty()
+        .slice().isize();
+
+    assert_eq!(
+        ty,
+        P(ast::Ty {
+            id: ast::DUMMY_NODE_ID,
+            node: ast::TyKind::Vec(builder.ty().isize()),
             span: DUMMY_SP,
         })
     );

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -78,7 +78,7 @@ fn test_array() {
         ty,
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
-            node: ast::TyKind::FixedLengthVec(AstBuilder::new().ty().usize(),
+            node: ast::TyKind::Array(AstBuilder::new().ty().usize(),
                 AstBuilder::new().expr().usize(3)
             ),
             span: DUMMY_SP,
@@ -204,7 +204,7 @@ fn test_slice() {
         ty,
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
-            node: ast::TyKind::Vec(builder.ty().isize()),
+            node: ast::TyKind::Slice(builder.ty().isize()),
             span: DUMMY_SP,
         })
     );

--- a/tests/test_ty_param.rs
+++ b/tests/test_ty_param.rs
@@ -14,6 +14,7 @@ fn test_ty_param_empty() {
     assert_eq!(
         ty_param,
         ast::TyParam {
+            attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
             bounds: P::new(),
@@ -34,6 +35,7 @@ fn test_ty_param_default() {
     assert_eq!(
         ty_param,
         ast::TyParam {
+            attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
             bounds: P::new(),
@@ -57,6 +59,7 @@ fn test_ty_param_bounds() {
     assert_eq!(
         ty_param,
         ast::TyParam {
+            attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
             bounds: P::from_vec(vec![

--- a/tests/test_ty_param.rs
+++ b/tests/test_ty_param.rs
@@ -7,6 +7,7 @@ use aster::path::IntoPath;
 use aster::lifetime::{IntoLifetime, IntoLifetimeDef};
 
 #[test]
+#[cfg(not(feature = "with-syntex"))]
 fn test_ty_param_empty() {
     let builder = AstBuilder::new();
     let ty_param = builder.ty_param("T").build();
@@ -25,6 +26,25 @@ fn test_ty_param_empty() {
 }
 
 #[test]
+#[cfg(feature = "with-syntex")]
+fn test_ty_param_empty() {
+    let builder = AstBuilder::new();
+    let ty_param = builder.ty_param("T").build();
+
+    assert_eq!(
+        ty_param,
+        ast::TyParam {
+            ident: builder.id("T"),
+            id: ast::DUMMY_NODE_ID,
+            bounds: P::new(),
+            default: None,
+            span: DUMMY_SP,
+        }
+    );
+}
+
+#[test]
+#[cfg(not(feature = "with-syntex"))]
 fn test_ty_param_default() {
     let builder = AstBuilder::new();
     let ty_param = builder.ty_param("T")
@@ -46,6 +66,28 @@ fn test_ty_param_default() {
 }
 
 #[test]
+#[cfg(feature = "with-syntex")]
+fn test_ty_param_default() {
+    let builder = AstBuilder::new();
+    let ty_param = builder.ty_param("T")
+        .default()
+        .usize()
+        .build();
+
+    assert_eq!(
+        ty_param,
+        ast::TyParam {
+            ident: builder.id("T"),
+            id: ast::DUMMY_NODE_ID,
+            bounds: P::new(),
+            default: Some(builder.ty().usize()),
+            span: DUMMY_SP,
+        }
+    );
+}
+
+#[test]
+#[cfg(not(feature = "with-syntex"))]
 fn test_ty_param_bounds() {
     let builder = AstBuilder::new();
     let ty_param = builder.ty_param("T")
@@ -60,6 +102,58 @@ fn test_ty_param_bounds() {
         ty_param,
         ast::TyParam {
             attrs: ast::ThinVec::new(),
+            ident: builder.id("T"),
+            id: ast::DUMMY_NODE_ID,
+            bounds: P::from_vec(vec![
+                ast::TyParamBound::TraitTyParamBound(
+                    ast::PolyTraitRef {
+                        bound_lifetimes: vec![
+                            "'a".into_lifetime_def(),
+                        ],
+                        trait_ref: ast::TraitRef {
+                            path: "Trait".into_path(),
+                            ref_id: ast::DUMMY_NODE_ID,
+                        },
+                        span: DUMMY_SP,
+                    },
+                    ast::TraitBoundModifier::None,
+                ),
+                ast::TyParamBound::TraitTyParamBound(
+                    ast::PolyTraitRef {
+                        bound_lifetimes: Vec::new(),
+                        trait_ref: ast::TraitRef {
+                            path: "Sized".into_path(),
+                            ref_id: ast::DUMMY_NODE_ID,
+                        },
+                        span: DUMMY_SP,
+                    },
+                    ast::TraitBoundModifier::Maybe,
+                ),
+                ast::TyParamBound::RegionTyParamBound(
+                    "'b".into_lifetime()
+                ),
+            ]),
+            default: None,
+            span: DUMMY_SP,
+        }
+    );
+}
+
+#[test]
+#[cfg(feature = "with-syntex")]
+fn test_ty_param_bounds() {
+    let builder = AstBuilder::new();
+    let ty_param = builder.ty_param("T")
+        .bound().trait_("Trait")
+            .lifetime("'a").build()
+            .build()
+        .bound().maybe_trait("Sized").build()
+        .bound().lifetime("'b")
+        .build();
+
+    assert_eq!(
+        ty_param,
+        ast::TyParam {
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
             bounds: P::from_vec(vec![


### PR DESCRIPTION
Fixes the failing build 667.2

libsyntax changed:
- TyKind::Vec was renamed to TyKind::Slice
- TyKind::FixedLengthVec was renamed to TyKind::Array
- ast::LifetimeDef and ast::TyParam got a new 'attrs' field

Fixes tested with rust 1.14.0 nightly 2016-10-03
cargo build and cargo test run cleanly
