### PR TITLE
Minimum update for API compat with libsyntax changes re: RFC 1624

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ with-syntex = ["syntex_syntax"]
 unstable-testing = ["clippy", "compiletest_rs"]
 
 [dependencies]
-syntex_syntax = { version = "^0.51.0", optional = true }
+syntex_syntax = { version = "^0.52.0", optional = true }
 clippy = { version = "0.*", optional = true }
 compiletest_rs = { version = "^0.2.0", optional = true }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -402,14 +402,14 @@ impl<F> ExprBuilder<F>
     }
 
     pub fn break_(self) -> F::Result {
-        self.build_expr_kind(ast::ExprKind::Break(None))
+        self.build_expr_kind(ast::ExprKind::Break(None, None))
     }
 
     pub fn break_to<I>(self, label: I) -> F::Result
         where I: ToIdent,
     {
         let label = respan(self.span, label.to_ident());
-        self.build_expr_kind(ast::ExprKind::Break(Some(label)))
+        self.build_expr_kind(ast::ExprKind::Break(Some(label), None))
     }
 
     pub fn continue_(self) -> F::Result {

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -254,7 +254,7 @@ fn test_break() {
 
     assert_eq!(
         expr,
-        builder.expr().build_expr_kind(ast::ExprKind::Break(None))
+        builder.expr().build_expr_kind(ast::ExprKind::Break(None, None))
     );
 
     let expr = builder.expr().break_to("'a");
@@ -262,7 +262,7 @@ fn test_break() {
 
     assert_eq!(
         expr,
-        builder.expr().build_expr_kind(ast::ExprKind::Break(Some(id)))
+        builder.expr().build_expr_kind(ast::ExprKind::Break(Some(id), None))
     );
 }
 


### PR DESCRIPTION
This commit adds `None` values for the "break-with-value" value to fix
breakage in recent nightlies.