### PR TITLE
 bring up to date with rustc 1.16.0-nightly (83c2d9523 2017-01-24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A libsyntax ast builder"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1905,7 +1905,7 @@ impl<F: Invoke<P<ast::Expr>>> ExprSliceBuilder<F>
     }
 
     pub fn build(self) -> F::Result {
-        self.builder.build_expr_kind(ast::ExprKind::Vec(self.exprs))
+        self.builder.build_expr_kind(ast::ExprKind::Array(self.exprs))
     }
 }
 

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -2,7 +2,6 @@ use std::iter::IntoIterator;
 
 use syntax::ast;
 use syntax::codemap::{DUMMY_SP, Span};
-use syntax::ptr::P;
 
 use ident::ToIdent;
 use invoke::{Invoke, Identity};
@@ -50,7 +49,7 @@ impl<F> GenericsBuilder<F>
             callback: callback,
             span: DUMMY_SP,
             lifetimes: generics.lifetimes,
-            ty_params: generics.ty_params.into_vec(),
+            ty_params: generics.ty_params,
             predicates: generics.where_clause.predicates,
         }
     }
@@ -200,7 +199,7 @@ impl<F> GenericsBuilder<F>
 
     pub fn strip_ty_params(mut self) -> Self {
         for ty_param in &mut self.ty_params {
-            ty_param.bounds = P::new();
+            ty_param.bounds = vec![];
         }
         self
     }
@@ -213,7 +212,7 @@ impl<F> GenericsBuilder<F>
     pub fn build(self) -> F::Result {
         self.callback.invoke(ast::Generics {
             lifetimes: self.lifetimes,
-            ty_params: P::from_vec(self.ty_params),
+            ty_params: self.ty_params,
             where_clause: ast::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: self.predicates,

--- a/src/item.rs
+++ b/src/item.rs
@@ -909,7 +909,7 @@ impl<F> ItemTraitBuilder<F>
         self.builder.build_item_kind(self.id, ast::ItemKind::Trait(
             self.unsafety,
             self.generics,
-            P::from_vec(self.bounds),
+            self.bounds,
             self.items,
         ))
     }
@@ -1123,7 +1123,7 @@ impl<F> ItemTraitTypeBuilder<F>
 
     pub fn build_option_ty(self, ty: Option<P<ast::Ty>>) -> F::Result {
         let bounds = P::from_vec(self.bounds);
-        let node = ast::TraitItemKind::Type(bounds, ty);
+        let node = ast::TraitItemKind::Type(bounds.into_vec(), ty);
         self.builder.build_item(node)
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -314,8 +314,8 @@ impl<F> PathSegmentBuilder<F>
         } else {
             let data = ast::AngleBracketedParameterData {
                 lifetimes: self.lifetimes,
-                types: P::from_vec(self.tys),
-                bindings: P::from_vec(self.bindings),
+                types: self.tys,
+                bindings: self.bindings,
             };
 
             Some(P(ast::PathParameters::AngleBracketed(data)))

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -199,13 +199,6 @@ impl<F> TyBuilder<F>
         TyBuilder::with_callback(TyIteratorBuilder(self)).span(span)
     }
 
-    pub fn object_sum(self) -> TyBuilder<TyObjectSumBuilder<F>> {
-        let span = self.span;
-        TyBuilder::with_callback(TyObjectSumBuilder {
-            builder: self,
-        }).span(span)
-    }
-
     pub fn impl_trait(self) -> TyImplTraitTyBuilder<F> {
         TyImplTraitTyBuilder { builder: self, bounds: Vec::new() }
     }
@@ -454,91 +447,6 @@ impl<F> Invoke<P<ast::Ty>> for TyIteratorBuilder<F>
 
 //////////////////////////////////////////////////////////////////////////////
 
-pub struct TyObjectSumBuilder<F> {
-    builder: TyBuilder<F>,
-}
-
-impl<F> Invoke<P<ast::Ty>> for TyObjectSumBuilder<F>
-    where F: Invoke<P<ast::Ty>>,
-{
-    type Result = TyObjectSumTyBuilder<F>;
-
-    fn invoke(self, ty: P<ast::Ty>) -> Self::Result {
-        TyObjectSumTyBuilder {
-            builder: self.builder,
-            ty: ty,
-            bounds: Vec::new(),
-        }
-    }
-}
-
-pub struct TyObjectSumTyBuilder<F> {
-    builder: TyBuilder<F>,
-    ty: P<ast::Ty>,
-    bounds: Vec<ast::TyParamBound>,
-}
-
-impl<F> TyObjectSumTyBuilder<F>
-    where F: Invoke<P<ast::Ty>>,
-{
-    pub fn with_bounds<I>(mut self, iter: I) -> Self
-        where I: Iterator<Item=ast::TyParamBound>,
-    {
-        self.bounds.extend(iter);
-        self
-    }
-
-    pub fn with_bound(mut self, bound: ast::TyParamBound) -> Self {
-        self.bounds.push(bound);
-        self
-    }
-
-    pub fn bound(self) -> TyParamBoundBuilder<Self> {
-        TyParamBoundBuilder::with_callback(self)
-    }
-
-    pub fn with_generics(self, generics: ast::Generics) -> Self {
-        self.with_lifetimes(
-            generics.lifetimes.into_iter()
-                .map(|def| def.lifetime)
-        )
-    }
-
-    pub fn with_lifetimes<I, L>(mut self, lifetimes: I) -> Self
-        where I: Iterator<Item=L>,
-              L: IntoLifetime,
-    {
-        for lifetime in lifetimes {
-            self = self.lifetime(lifetime);
-        }
-
-        self
-    }
-
-    pub fn lifetime<L>(self, lifetime: L) -> Self
-        where L: IntoLifetime,
-    {
-        self.bound().lifetime(lifetime)
-    }
-
-    pub fn build(self) -> F::Result {
-        let bounds = P::from_vec(self.bounds);
-        self.builder.build_ty_kind(ast::TyKind::ObjectSum(self.ty, bounds))
-    }
-}
-
-impl<F> Invoke<ast::TyParamBound> for TyObjectSumTyBuilder<F>
-    where F: Invoke<P<ast::Ty>>,
-{
-    type Result = Self;
-
-    fn invoke(self, bound: ast::TyParamBound) -> Self {
-        self.with_bound(bound)
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
 pub struct TyImplTraitTyBuilder<F> {
     builder: TyBuilder<F>,
     bounds: Vec<ast::TyParamBound>,
@@ -588,8 +496,7 @@ impl<F> TyImplTraitTyBuilder<F>
     }
 
     pub fn build(self) -> F::Result {
-        let bounds = P::from_vec(self.bounds);
-        self.builder.build_ty_kind(ast::TyKind::ImplTrait(bounds))
+        self.builder.build_ty_kind(ast::TyKind::ImplTrait(self.bounds))
     }
 }
 
@@ -644,3 +551,16 @@ impl<F> Invoke<P<ast::Ty>> for TyTupleBuilder<F>
         self.with_ty(ty)
     }
 }
+
+
+//////////////////////////////////////////////////////////////////////////////
+
+/*
+pub trait IntoTy {
+    fn into_ty(&self) -> ast::Ty;
+}
+
+impl<'a> IntoTy for &'a str {
+    TyBuilder
+}
+*/

--- a/src/ty_param.rs
+++ b/src/ty_param.rs
@@ -51,7 +51,7 @@ impl<F> TyParamBuilder<F>
             callback: callback,
             span: ty_param.span,
             id: ty_param.ident,
-            bounds: ty_param.bounds.into_vec(),
+            bounds: ty_param.bounds,
             default: ty_param.default,
         }
     }
@@ -104,7 +104,7 @@ impl<F> TyParamBuilder<F>
             attrs: ast::ThinVec::new(),
             ident: self.id,
             id: ast::DUMMY_NODE_ID,
-            bounds: P::from_vec(self.bounds),
+            bounds: self.bounds,
             default: self.default,
             span: self.span,
         })

--- a/src/where_predicate.rs
+++ b/src/where_predicate.rs
@@ -53,13 +53,13 @@ impl<F> WherePredicateBuilder<F>
         }
     }
 
-    pub fn eq<P>(self, path: P) -> WhereEqPredicateBuilder<F>
+    pub fn eq<P>(self, p: P) -> WhereEqPredicateBuilder<F>
         where P: IntoPath,
     {
         WhereEqPredicateBuilder {
             callback: self.callback,
             span: self.span,
-            path: path.into_path(),
+            lhs: TyBuilder::new().build_path(p.into_path()),
         }
     }
 }
@@ -240,7 +240,7 @@ impl<F> WhereBoundPredicateTyBoundsBuilder<F>
             span: self.span,
             bound_lifetimes: self.bound_lifetimes,
             bounded_ty: self.ty,
-            bounds: P::from_vec(self.bounds),
+            bounds: self.bounds,
         };
 
         self.callback.invoke(ast::WherePredicate::BoundPredicate(predicate))
@@ -302,7 +302,7 @@ impl<F> WhereRegionPredicateBuilder<F>
 pub struct WhereEqPredicateBuilder<F> {
     callback: F,
     span: Span,
-    path: ast::Path,
+    lhs: P<ast::Ty>,
 }
 
 impl<F> WhereEqPredicateBuilder<F>
@@ -314,13 +314,13 @@ impl<F> WhereEqPredicateBuilder<F>
     }
 
     pub fn build_ty(self, ty: P<ast::Ty>) -> F::Result {
-        let WhereEqPredicateBuilder { callback, span, path } = self;
+        let WhereEqPredicateBuilder { callback, span, lhs } = self;
 
         let predicate = ast::WhereEqPredicate {
             id: ast::DUMMY_NODE_ID,
             span: span,
-            path: path,
-            ty: ty,
+            lhs_ty: lhs,
+            rhs_ty: ty,
         };
 
         callback.invoke(ast::WherePredicate::EqPredicate(predicate))

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -212,7 +212,7 @@ fn test_slice() {
         expr,
         P(ast::Expr {
             id: ast::DUMMY_NODE_ID,
-            node: ast::ExprKind::Vec(vec![
+            node: ast::ExprKind::Array(vec![
                 builder.expr().i8(1),
                 builder.expr().i8(2),
                 builder.expr().i8(3),

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -1,5 +1,4 @@
 use syntax::ast;
-use syntax::ptr::P;
 use syntax::codemap::DUMMY_SP;
 
 use aster::AstBuilder;
@@ -13,7 +12,7 @@ fn test_empty() {
         generics,
         ast::Generics {
             lifetimes: vec![],
-            ty_params: P::new(),
+            ty_params: vec![],
             where_clause: ast::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: vec![],
@@ -39,9 +38,9 @@ fn test_with_ty_params_and_lifetimes() {
                 builder.lifetime_def("'a").build(),
                 builder.lifetime_def("'b").bound("'a").build(),
             ],
-            ty_params: P::from_vec(vec![
+            ty_params: vec![
                 builder.ty_param("T").lifetime_bound("'a").build(),
-            ]),
+            ],
             where_clause: ast::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: vec![],

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -551,15 +551,14 @@ fn test_trait() {
             node: ast::ItemKind::Trait(
                 ast::Unsafety::Normal,
                 builder.generics().build(),
-                P::from_vec(vec![
-                ]),
+                vec![],
                 vec![
                     ast::TraitItem {
                         id: ast::DUMMY_NODE_ID,
                         ident: builder.id("MyFloat"),
                         attrs: vec![],
                         node: ast::TraitItemKind::Type(
-                            P::from_vec(vec![]),
+                            vec![],
                             None,
                         ),
                         span: DUMMY_SP,

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -105,10 +105,10 @@ fn test_option() {
                     identifier: builder.id("Option"),
                     parameters: Some(P(ast::AngleBracketed(ast::AngleBracketedParameterData {
                         lifetimes: vec![],
-                        types: P::from_vec(vec![
+                        types: vec![
                             builder.ty().isize(),
-                        ]),
-                        bindings: P::new(),
+                        ],
+                        bindings: vec![],
                     }))),
                 },
             ]
@@ -136,8 +136,8 @@ fn test_lifetimes() {
                         lifetimes: vec![
                             builder.lifetime("'a"),
                         ],
-                        types: P::new(),
-                        bindings: P::new(),
+                        types: vec![],
+                        bindings: vec![],
                     }))),
                 },
             ]

--- a/tests/test_ty_param.rs
+++ b/tests/test_ty_param.rs
@@ -1,6 +1,5 @@
 use syntax::ast;
 use syntax::codemap::DUMMY_SP;
-use syntax::ptr::P;
 
 use aster::AstBuilder;
 use aster::path::IntoPath;
@@ -17,7 +16,7 @@ fn test_ty_param_empty() {
             attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
-            bounds: P::new(),
+            bounds: vec![],
             default: None,
             span: DUMMY_SP,
         }
@@ -38,7 +37,7 @@ fn test_ty_param_default() {
             attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
-            bounds: P::new(),
+            bounds: vec![],
             default: Some(builder.ty().usize()),
             span: DUMMY_SP,
         }
@@ -62,7 +61,7 @@ fn test_ty_param_bounds() {
             attrs: ast::ThinVec::new(),
             ident: builder.id("T"),
             id: ast::DUMMY_NODE_ID,
-            bounds: P::from_vec(vec![
+            bounds: vec![
                 ast::TyParamBound::TraitTyParamBound(
                     ast::PolyTraitRef {
                         bound_lifetimes: vec![
@@ -90,7 +89,7 @@ fn test_ty_param_bounds() {
                 ast::TyParamBound::RegionTyParamBound(
                     "'b".into_lifetime()
                 ),
-            ]),
+            ],
             default: None,
             span: DUMMY_SP,
         }

--- a/tests/test_where_predicate.rs
+++ b/tests/test_where_predicate.rs
@@ -1,8 +1,8 @@
 use syntax::ast;
 use syntax::codemap::DUMMY_SP;
-use syntax::ptr::P;
 
 use aster::AstBuilder;
+use aster::ty::TyBuilder;
 use aster::lifetime::{IntoLifetime, IntoLifetimeDef};
 use aster::path::IntoPath;
 
@@ -22,11 +22,11 @@ fn test_bound() {
                 "'a".into_lifetime_def(),
             ],
             bounded_ty: builder.ty().id("T"),
-            bounds: P::from_vec(vec![
+            bounds: vec![
                 builder.ty_param_bound()
                     .trait_("Trait")
                     .build(),
-            ]),
+            ],
         })
     );
 }
@@ -62,8 +62,8 @@ fn test_eq() {
         ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
             id: ast::DUMMY_NODE_ID,
             span: DUMMY_SP,
-            path: "T".into_path(),
-            ty: builder.ty().usize(),
+            lhs_ty: TyBuilder::new().build_path("T".into_path()),
+            rhs_ty: builder.ty().usize(),
         })
     );
 }


### PR DESCRIPTION
1. lots of things moved from ptr::P to simply a Vec
2. ObjectSum type is gone (in upstream, thus here)
3. WhereEqPredicate now takes two ast::Ty rather than an ast::Path and ast::Ty
3.a. simply wraps the ast::Path in an ast::Ty
4. ast::ExprKind::Vec turned into ast::ExprKind::Array